### PR TITLE
Added DynamoDB table for Terraform state locking

### DIFF
--- a/aws/bootstrap_backend/main.tf
+++ b/aws/bootstrap_backend/main.tf
@@ -1,5 +1,10 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_s3_bucket" "tf_state" {
   bucket = "gsingh-terraform-state-bucket"
+
   lifecycle {
     prevent_destroy = true
   }
@@ -19,11 +24,29 @@ resource "aws_s3_bucket_versioning" "versioning" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "encryption" {
-  bucket = aws_s3_bucket.tf_state.bucket
+  bucket = aws_s3_bucket.tf_state.id
 
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }
+  }
+}
+
+# Dynamodb config
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name           = "terraform-locks"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "Terraform State Lock Table"
+    Environment = "Bootstrap"
   }
 }

--- a/aws/ec2/backend.tf
+++ b/aws/ec2/backend.tf
@@ -1,8 +1,9 @@
 terraform {
   backend "s3" {
-    bucket  = "gsingh-terraform-state-bucket"
-    key     = "ec2/terraform.tfstate"
-    region  = "us-west-2"
-    encrypt = true
+    bucket         = "gsingh-terraform-state-bucket"
+    key            = "ec2/terraform.tfstate"
+    region         = "us-west-2"
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
   }
 }

--- a/aws/vpc/backend.tf
+++ b/aws/vpc/backend.tf
@@ -4,5 +4,6 @@ terraform {
     key            = "vpc/terraform.tfstate"
     region         = "us-west-2"
     encrypt        = true
+    dynamodb_table = "terraform-locks"
   }
 }


### PR DESCRIPTION
Created DynamoDB table terraform-locks with LockID as the primary key

Updated backend.tf to reference the DynamoDB table for state locking

Verified backend integration across VPC and EC2 Terraform folders