### PR TITLE
Added User data to bastion, create ssm role for bastion

### DIFF
--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -49,6 +49,25 @@ resource "aws_instance" "bastion_vm" {
   subnet_id              = var.public_subnet_id
   key_name               = "gurjit-ed25519"
   vpc_security_group_ids = [aws_security_group.bastion_sg.id]
+  iam_instance_profile   = "bastion-ssm-profile"
+
+  user_data = <<-EOF
+              #!/bin/bash
+              mkdir -p /home/ec2-user/.ssh
+
+              for i in {1..5}; do
+                aws ssm get-parameter \
+                  --name "/infra/infra-ssh-key" \
+                  --with-decryption \
+                  --region us-west-2 \
+                  --query "Parameter.Value" \
+                  --output text > /home/ec2-user/.ssh/infra-ssh-key.pem && break
+                sleep 5
+              done
+
+              chown ec2-user:ec2-user /home/ec2-user/.ssh/infra-ssh-key.pem
+              chmod 600 /home/ec2-user/.ssh/infra-ssh-key.pem
+              EOF
 
   tags = {
     Name = "bastion"

--- a/aws/iam/.terraform.lock.hcl
+++ b/aws/iam/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.7.0"
+  hashes = [
+    "h1:vISrEI1xUh0w7NXTQ9m6ZEnQ1dv02yy+EJvxW78DAoI=",
+    "zh:3c0a256f813e5e2c1e1aa137204ad9168ebe487f6cee874af9e9c78eb300568e",
+    "zh:3c49dd75ea28395b29ba259988826b956c8adf6c0b59dd8874feb4f47bad976a",
+    "zh:3e6e3e3bfc6594f4f9e2c017ee588c5fcad394b87dd0b68a3f37cd66001f3c8c",
+    "zh:3f9b55826eeebf9b2ed448fc111d772c703e1edc6678e1bb646e66f3c3f9308f",
+    "zh:44e4ced936045ddc42d22c653a6427e7eb2b7aee918dff8438da0cb40996beb4",
+    "zh:474ab4d63918f41e8ea1cef43aeb1c719629dbf289db175c95de1431a8853ae7",
+    "zh:71b9e1d82c5ccc8d9bf72b3712c2b90722fc1f35a0f0f7a9557b9ee01971e6e2",
+    "zh:7723256d6ccc55f4000d1df8db202b02b30a7d917f5d31624c717e14ba15ea95",
+    "zh:82174836faa830aff0e47ea61d4cfbb5c97e1e944b1978f1d933acd37f584c88",
+    "zh:8e62fdc10206ba7232eec991e5a387378f2fbe47cc717b7f60eeb1df2c974514",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:be24dd2d53b224d7098e75ca432746e3420ce071189eea100aa8cbcd2498d389",
+    "zh:d27651d0e458933127ddca35a833e1a0f0ff0c131391288b3239763a2fd8f96f",
+    "zh:d33c181fff1b96bf8366e6c3d92408370b21649291e8f4d1f7e9a3fbb920fc9d",
+    "zh:edc0a0a84f85036c6d3df29d09557bd43206d9ee57b10542b484050f0f34d242",
+  ]
+}

--- a/aws/iam/backend.tf
+++ b/aws/iam/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "gsingh-terraform-state-bucket"
+    key            = "iam/terraform.tfstate"
+    region         = "us-west-2"
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
+  }
+}

--- a/aws/iam/data.tf
+++ b/aws/iam/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/aws/iam/main.tf
+++ b/aws/iam/main.tf
@@ -1,0 +1,50 @@
+resource "aws_iam_role" "bastion_ssm_role" {
+  name = "bastion-ssm-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name = "Bastion SSM Role"
+  }
+}
+
+resource "aws_iam_policy" "ssm_parameter_read" {
+  name        = "ssm-parameter-read-policy"
+  description = "Allows EC2 to read private SSH key from SSM Parameter Store"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath"
+        ],
+        Resource = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/infra/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_policy" {
+  role       = aws_iam_role.bastion_ssm_role.name
+  policy_arn = aws_iam_policy.ssm_parameter_read.arn
+}
+
+resource "aws_iam_instance_profile" "bastion_profile" {
+  name = "bastion-ssm-profile"
+  role = aws_iam_role.bastion_ssm_role.name
+}

--- a/aws/iam/output.tf
+++ b/aws/iam/output.tf
@@ -1,0 +1,4 @@
+output "bastion_instance_profile" {
+  description = "IAM Instance Profile to attach to Bastion Host"
+  value       = aws_iam_instance_profile.bastion_profile.name
+}

--- a/aws/iam/variables.tf
+++ b/aws/iam/variables.tf
@@ -1,0 +1,4 @@
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,0 +1,11 @@
+variable "instance_name" {
+  description = "Value of the EC2 instance's Name tag."
+  type        = string
+  default     = "learn-terraform"
+}
+
+variable "instance_type" {
+  description = "The EC2 instance's type."
+  type        = string
+  default     = "t2.micro"
+}


### PR DESCRIPTION
Added bastion-ssm-role with SSM read permissions

Created ssm-parameter-read-policy for /infra/* path

Attached policy via bastion-ssm-profile

Updated EC2 user data to:

    Fetch and save the PEM key from SSM

    Set appropriate permissions

 Benefits

    Removes need for hardcoded keys

    Automates secure key injection at instance boot

    Follows AWS best practices for credential management